### PR TITLE
Depreceted libstdc++.6.0.9.dylib

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ $ yarn add react-native-openalpr
 $ cd ios && pod install && cd ..
 ```
 
+#### Add post_install tweeks into Podfile
+
+There is workaround for a missing _libstdc++.6.0.9.dylib_ in newer xcode. Please refer to _example/ios/Podfile_. Remember to set _target.name_ when copy pasting.
+
+There is also an workaround for xcode 12.5 if neeeded.
+
 #### Camera Permissions
 
 - Add an entry for `NSCameraUsageDescription` in your `info.plist` explaining why your app will use the camera. If you forget to add this, your app will crash!

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -37,4 +37,37 @@ target 'RNOpenALPRExample' do
   pod 'Permission-Camera', :path => "../node_modules/react-native-permissions/ios/Camera.podspec"
 
   use_native_modules!
+
+  post_install do |installer|
+    installer.pods_project.targets.each do |target|
+      if target.name == "Pods-RNOpenALPRExample"
+          puts "Updating #{target.name} -weak library usage"
+          target.build_configurations.each do |config|
+              xcconfig_path = config.base_configuration_reference.real_path
+              xcconfig = File.read(xcconfig_path)
+              new_xcconfig = xcconfig.sub('-weak_library /usr/lib/libstdc++.6.0.9.dylib', '')
+              File.open(xcconfig_path, "w") { |file| file << new_xcconfig }
+          end
+      end
+    end
+
+    ## Fix for XCode 12.5
+    find_and_replace("../node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm", "_initializeModules:(NSArray<id<RCTBridgeModule>> *)modules", "_initializeModules:(NSArray<Class> *)modules")
+    find_and_replace("../node_modules/react-native/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm", "RCTBridgeModuleNameForClass(module))", "RCTBridgeModuleNameForClass(Class(module)))")
+  end
+
+  def find_and_replace(dir, findstr, replacestr)
+    Dir[dir].each do |name|
+        text = File.read(name)
+        replace = text.gsub(findstr,replacestr)
+        if text != replace
+            puts "Fix: " + name
+            File.open(name, "w") { |file| file.puts replace }
+            STDOUT.flush
+        end
+    end
+    Dir[dir + '*/'].each(&method(:find_and_replace))
+  end
+
 end
+

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -185,7 +185,7 @@ PODS:
     - React-cxxreact (= 0.61.1)
     - React-jsi (= 0.61.1)
   - React-jsinspector (0.61.1)
-  - react-native-openalpr (1.2.0):
+  - react-native-openalpr (2.1.1):
     - OpenCV (~> 3.1.0.1)
     - React
     - TesseractOCRiOS (~> 3.03)
@@ -263,7 +263,7 @@ DEPENDENCIES:
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - boost-for-react-native
     - OpenCV
     - TesseractOCRiOS
@@ -344,7 +344,7 @@ SPEC CHECKSUMS:
   React-jsi: 61ff417c95e6c3af50fb96399037e80752fb5ce7
   React-jsiexecutor: ee45274419eb95614bbbadb98e20684c5f29996e
   React-jsinspector: 574d597112f9ea3d1b717f6fb62aef764c70dd6f
-  react-native-openalpr: e9b725611a7cb7fe1155840b55f10c96c3fb674b
+  react-native-openalpr: 5d8e21c5bfddc3fb66f5d0ee4a9b9502e3f5ad93
   React-RCTActionSheet: af4d951113b1e068bb30611f91b984a7a73597ff
   React-RCTAnimation: 4f518d70bb6890b7c3d9d732f84786d6693ca297
   React-RCTBlob: 072a4888c08de0eef6d04eaa727d25e577e6ff26
@@ -359,6 +359,6 @@ SPEC CHECKSUMS:
   TesseractOCRiOS: cd79d4ce9d4c0f1e2776db8820cf8239e5569592
   Yoga: d8c572ddec8d05b7dba08e4e5f1924004a177078
 
-PODFILE CHECKSUM: feaa7cf28a4ce22946f07c7febe93fd4426b6cd3
+PODFILE CHECKSUM: b7ceb573c2bc7b9657221fd7f45264cc2cd4dea1
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.10.1


### PR DESCRIPTION
- Workaroud for deprecated libstdc++.6.0.9.dylib, https://github.com/RobertSasak/react-native-openalpr/issues/105#issuecomment-780568449
- Cannot build on xcode 12.5 https://github.com/facebook/react-native/issues/28405#issuecomment-827424477