### PR TITLE
Implement pinch to zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,3 +284,7 @@ Note: If you are getting errors, double check that you have completed all of the
 
 - OpenALPR built from [OpenALPR-iOS](https://github.com/twelve17/openalpr-ios)
 - Project scaffold based on [react-native-camera](https://github.com/lwansbrough/react-native-camera)
+
+## Sponsors
+
+- [repocoin.io](https://repocoin.io)

--- a/example/App.js
+++ b/example/App.js
@@ -317,7 +317,7 @@ export default class App extends Component {
         </TouchableOpacity>
         <Text style={styles.plateText}>{plate}</Text>
         <Text style={styles.confidenceText}>
-          {confidence ? confidence + '%' : ''}
+          {confidence ? (+confidence).toFixed(1) + '%' : ''}
         </Text>
         <TouchableOpacity
           style={styles.takePicture}

--- a/ios/ALPRCamera.m
+++ b/ios/ALPRCamera.m
@@ -163,6 +163,14 @@
         {
             [self.camFocus removeFromSuperview];
         }
+        NSDictionary *event = @{
+          @"target": self.reactTag,
+          @"touchPoint": @{
+            @"x": [NSNumber numberWithDouble:touchPoint.x],
+            @"y": [NSNumber numberWithDouble:touchPoint.y]
+          }
+        };
+        [self.bridge.eventDispatcher sendAppEventWithName:@"focusChanged" body:event];
 
         // Show animated rectangle on the touched area
         if (_touchToFocus) {
@@ -181,13 +189,12 @@
     if (allTouchesEnded) {
         _multipleTouches = NO;
     }
-    
+
 }
 
 -(void) handlePinchToZoomRecognizer:(UIPinchGestureRecognizer*)pinchRecognizer {
-
     if (pinchRecognizer.state == UIGestureRecognizerStateChanged) {
-        return;
+        [self.manager zoom:pinchRecognizer.velocity reactTag:self.reactTag];
     }
 }
 

--- a/ios/ALPRCameraManager.h
+++ b/ios/ALPRCameraManager.h
@@ -54,5 +54,6 @@ typedef NS_ENUM(NSInteger, ALPRCameraTorchMode) {
 - (void)startSession;
 - (void)stopSession;
 - (void)focusAtThePoint:(CGPoint) atPoint;
+- (void)zoom:(CGFloat)velocity reactTag:(NSNumber *)reactTag;
 
 @end


### PR DESCRIPTION
Zoom functionality allows to pinch the camera video with two fingers and zoom in. This help to scan licence plate that are more far away. 

This PR war requested by @kamellababidi in https://github.com/RobertSasak/react-native-openalpr/issues/106 and sponsored by [repocoin.io](https://repocoin.io)